### PR TITLE
Add org select to profiles, fix display on event post profiles

### DIFF
--- a/js/OrgAutoComplete.js
+++ b/js/OrgAutoComplete.js
@@ -2,39 +2,39 @@ CRM.$(function($) {
   $('#oac-wrapper').insertAfter('#current_employer');
 
   $("#org_switcher").click(function(){
-  	var data = $(this).text();
-		$(this).text(data === 'Select Organization' ? 'Add New Organization' : 'Select Organization');
+    var data = $(this).text();
+    $(this).text(data === 'Select Organization' ? 'Add New Organization' : 'Select Organization');
 
-		if (data === "Add New Organization"){
+    if (data === "Add New Organization"){
       $('#current_employer').val('').show();
       $('div#oac-org-select').val('').hide();
 
       //$('#current_employer').val("");
-			//$('#s2id_current_employer').hide();
-			//$('.select2-choice').addClass('select2-default');
-			//$('.select2-chosen').text('- Select Organization -');
-			//$('label[for="employer_id"]').hide();
-			//$('#organization_name').show();
-			//$('label[for="organization_name"]').show();
-		}
+      //$('#s2id_current_employer').hide();
+      //$('.select2-choice').addClass('select2-default');
+      //$('.select2-chosen').text('- Select Organization -');
+      //$('label[for="employer_id"]').hide();
+      //$('#organization_name').show();
+      //$('label[for="organization_name"]').show();
+    }
 
-		if (data === "Select Organization"){
+    if (data === "Select Organization"){
       $('#current_employer').val('').hide();
       $('div#oac-org-select').val('').show();
 
-			//$("#organization_name").val('').hide();
-			//$('label[for="organization_name"]').hide();
-			//$('#s2id_current_employer').show();
-			//$('label[for="employer_id"]').show();
-		}
-	});
+      //$("#organization_name").val('').hide();
+      //$('label[for="organization_name"]').hide();
+      //$('#s2id_current_employer').show();
+      //$('label[for="employer_id"]').show();
+    }
+  });
 
   //default display select field/hide text field
   $('#current_employer').val('').hide();
   $('div#oac-org-select').val('').show();
 
   //$('#organization_name').width(220).hide();
-	//$('label[for="organization_name"]').hide();
-	//$('#s2id_current_employer').show();
-	//$('label[for="employer_id"]').show();
+  //$('label[for="organization_name"]').hide();
+  //$('#s2id_current_employer').show();
+  //$('label[for="employer_id"]').show();
 });

--- a/orgautocomplete.php
+++ b/orgautocomplete.php
@@ -211,20 +211,25 @@ function orgautocomplete_civicrm_buildForm($formName, &$form) {
           'id' => $params['org_select'],
           'return' => 'display_name',
         ]);
-        //Civi::log()->debug('', ['$orgName' => $orgName]);
+        // Civi::log()->debug('', ['$orgName' => $orgName]);
 
         if (!empty($orgName)) {
           //get the label for the field so we can set as key
           $fieldLabel = $form->_fields['current_employer']['title'];
-          //Civi::log()->debug('', ['$fieldLabel' => $fieldLabel]);
+          // Civi::log()->debug('', ['$fieldLabel' => $fieldLabel]);
 
           //cycle through pre/post in tplVars and assign value
-          foreach (['CustomPre', 'CustomPost'] as $profile) {
-            if (isset($tplVars['primaryParticipantProfile'][$profile][$fieldLabel])) {
-              $tplVars['primaryParticipantProfile'][$profile][$fieldLabel] = $orgName;
+          if (isset($tplVars['primaryParticipantProfile']['CustomPre'][$fieldLabel])) {
+            $tplVars['primaryParticipantProfile']['CustomPre'][$fieldLabel] = $orgName;
+            $form->assign('primaryParticipantProfile', $tplVars['primaryParticipantProfile']);
+          }
+          foreach ($tplVars['primaryParticipantProfile']['CustomPost'] as $profileId => $profile) {
+            if (isset($tplVars['primaryParticipantProfile']['CustomPost'][$profileId][$fieldLabel])) {
+              $tplVars['primaryParticipantProfile']['CustomPost'][$profileId][$fieldLabel] = $orgName;
               $form->assign('primaryParticipantProfile', $tplVars['primaryParticipantProfile']);
             }
           }
+
         }
       }
       catch (CRM_API3_Exception $e) {}


### PR DESCRIPTION
Work for profiles for me on CiviCRM 5.17 with some front end profile create/edit. May need tested for regressions. I ran through a couple of event registrations, all seemed well. I did notice that since there are multiple post profiles, it was not doing the correct replace.